### PR TITLE
fix compilation error with gcc 7.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ CC_opt = $(DEFAULT_CC)
 CXX_opt = $(DEFAULT_CXX)
 LD_opt = $(DEFAULT_CC)
 LDXX_opt = $(DEFAULT_CXX)
-CPPFLAGS_opt = -O2
+CPPFLAGS_opt = -O2 -Wno-unused -Wno-deprecated-declarations
 DEFINES_opt = NDEBUG
 
 VALID_CONFIG_asan-trace-cmp = 1

--- a/src/core/ext/transport/chttp2/transport/bin_decoder.c
+++ b/src/core/ext/transport/chttp2/transport/bin_decoder.c
@@ -133,6 +133,7 @@ bool grpc_base64_decode_partial(struct grpc_base64_decode_context *ctx) {
       switch (input_tail) {
         case 3:
           ctx->output_cur[1] = COMPOSE_OUTPUT_BYTE_1(ctx->input_cur);
+          __attribute__ ((fallthrough));
         case 2:
           ctx->output_cur[0] = COMPOSE_OUTPUT_BYTE_0(ctx->input_cur);
       }

--- a/src/core/ext/transport/chttp2/transport/varint.c
+++ b/src/core/ext/transport/chttp2/transport/varint.c
@@ -52,12 +52,16 @@ void grpc_chttp2_hpack_write_varint_tail(uint32_t tail_value, uint8_t* target,
   switch (tail_length) {
     case 5:
       target[4] = (uint8_t)((tail_value >> 28) | 0x80);
+      __attribute__ ((fallthrough));
     case 4:
       target[3] = (uint8_t)((tail_value >> 21) | 0x80);
+      __attribute__ ((fallthrough));
     case 3:
       target[2] = (uint8_t)((tail_value >> 14) | 0x80);
+      __attribute__ ((fallthrough));
     case 2:
       target[1] = (uint8_t)((tail_value >> 7) | 0x80);
+      __attribute__ ((fallthrough));
     case 1:
       target[0] = (uint8_t)((tail_value) | 0x80);
   }

--- a/src/core/ext/transport/cronet/transport/cronet_transport.c
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.c
@@ -664,7 +664,7 @@ static void create_grpc_frame(grpc_slice_buffer *write_slice_buffer,
   uint8_t *p = (uint8_t *)write_buffer;
   /* Append 5 byte header */
   /* Compressed flag */
-  *p++ = (flags & GRPC_WRITE_INTERNAL_COMPRESS) ? 1 : 0;
+  *p++ = (uint8_t) (flags & GRPC_WRITE_INTERNAL_COMPRESS) ? 1 : 0;
   /* Message length */
   *p++ = (uint8_t)(length >> 24);
   *p++ = (uint8_t)(length >> 16);

--- a/src/core/lib/json/json_reader.c
+++ b/src/core/lib/json/json_reader.c
@@ -192,6 +192,7 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader *reader) {
             if (!success) return GRPC_JSON_PARSE_ERROR;
             json_reader_string_clear(reader);
             reader->state = GRPC_JSON_STATE_VALUE_END;
+            __attribute__ ((fallthrough));
           /* The missing break here is intentional. */
 
           case GRPC_JSON_STATE_VALUE_END:

--- a/src/core/lib/security/credentials/jwt/jwt_verifier.c
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.c
@@ -477,6 +477,35 @@ static BIGNUM *bignum_from_base64(grpc_exec_ctx *exec_ctx, const char *b64) {
   return result;
 }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+// Provide compatibility across OpenSSL 1.02 and 1.1.
+static int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d) {
+  /* If the fields n and e in r are NULL, the corresponding input
+   * parameters MUST be non-NULL for n and e.  d may be
+   * left NULL (in case only the public key is used).
+   */
+  if ((r->n == NULL && n == NULL) || (r->e == NULL && e == NULL)) {
+    return 0;
+  }
+
+  if (n != NULL) {
+    BN_free(r->n);
+    r->n = n;
+  }
+  if (e != NULL) {
+    BN_free(r->e);
+    r->e = e;
+  }
+  if (d != NULL) {
+    BN_free(r->d);
+    r->d = d;
+  }
+
+  return 1;
+}
+#endif  // OPENSSL_VERSION_NUMBER < 0x10100000L
+
 static EVP_PKEY *pkey_from_jwk(grpc_exec_ctx *exec_ctx, const grpc_json *json,
                                const char *kty) {
   const grpc_json *key_prop;
@@ -493,19 +522,25 @@ static EVP_PKEY *pkey_from_jwk(grpc_exec_ctx *exec_ctx, const grpc_json *json,
     gpr_log(GPR_ERROR, "Could not create rsa key.");
     goto end;
   }
+  BIGNUM *tmp_n = NULL;
+  BIGNUM *tmp_e = NULL;
   for (key_prop = json->child; key_prop != NULL; key_prop = key_prop->next) {
     if (strcmp(key_prop->key, "n") == 0) {
-      rsa->n =
+      tmp_n =
           bignum_from_base64(exec_ctx, validate_string_field(key_prop, "n"));
-      if (rsa->n == NULL) goto end;
+      if (tmp_n == NULL) goto end;
     } else if (strcmp(key_prop->key, "e") == 0) {
-      rsa->e =
+      tmp_e =
           bignum_from_base64(exec_ctx, validate_string_field(key_prop, "e"));
-      if (rsa->e == NULL) goto end;
+      if (tmp_e == NULL) goto end;
     }
   }
-  if (rsa->e == NULL || rsa->n == NULL) {
+  if (tmp_e == NULL || tmp_n == NULL) {
     gpr_log(GPR_ERROR, "Missing RSA public key field.");
+    goto end;
+  }
+  if (!RSA_set0_key(rsa, tmp_n, tmp_e, NULL)) {
+    gpr_log(GPR_ERROR, "Cannot set RSA key from inputs.");
     goto end;
   }
   result = EVP_PKEY_new();

--- a/src/core/lib/support/murmur_hash.c
+++ b/src/core/lib/support/murmur_hash.c
@@ -77,8 +77,10 @@ uint32_t gpr_murmur_hash3(const void *key, size_t len, uint32_t seed) {
   switch (len & 3) {
     case 3:
       k1 ^= ((uint32_t)tail[2]) << 16;
+      __attribute__ ((fallthrough));
     case 2:
       k1 ^= ((uint32_t)tail[1]) << 8;
+      __attribute__ ((fallthrough));
     case 1:
       k1 ^= tail[0];
       k1 *= c1;


### PR DESCRIPTION
- fix compilation error fallthrough case by adding explicit fall through compilation directive
- casting error due to int -> uint8_t conversion
- compatibility issue related openssl version between 1.02 and 1.1




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
